### PR TITLE
レスポンスに警告コードが含まれている場合はfalseを返すようにした

### DIFF
--- a/example/medical_practice_service/calc_medical_practice_fee.rb
+++ b/example/medical_practice_service/calc_medical_practice_fee.rb
@@ -7,16 +7,16 @@ Usage:
   exit(1)
 end
 
-require_relative "../common"
+require_relative "./common"
 
 service = @orca_api.new_medical_practice_service
 
 args = JSON.parse(File.read(ARGV.shift))
 
-result = service.calc_medical_practice_fee(args)
+result = process_medical_warnings(service, :calc_medical_practice_fee, args)
 if result.ok?
   $stderr.puts "＊＊＊＊＊正常終了＊＊＊＊＊"
-  $stderr.puts "標準出力に出力したJSONを適宜修正してファイルに保存してcreate.rbの引数に指定してください"
+  $stderr.puts "標準出力に出力したJSONを適宜修正してファイルに保存してcrud.rb createの引数に指定してください"
 
   args["Diagnosis_Information"]["Medical_Information"]["Medical_Info"] = result["Medical_Information"]["Medical_Info"]
 

--- a/example/medical_practice_service/common.rb
+++ b/example/medical_practice_service/common.rb
@@ -1,0 +1,20 @@
+require_relative "../common"
+
+def process_medical_warnings(service, method_name, args)
+  while !((result = service.send(method_name, args)).ok?)
+    if !result.warning? || result.medical_warnings.empty?
+      return result
+    end
+    result.medical_warnings.each do |i|
+      puts("＊＊＊＊＊警告＊＊＊＊＊")
+      puts(i.values.join("\n"))
+      print("警告を無視して処理を進めますか? (Y/n)")
+      if /\An/ =~ (gets || "").strip.downcase
+        return result
+      end
+      args["Ignore_Medical_Warnings"] ||= []
+      args["Ignore_Medical_Warnings"] << { "Medical_Warning" => i["Medical_Warning"] }
+    end
+  end
+  result
+end

--- a/example/medical_practice_service/crud.rb
+++ b/example/medical_practice_service/crud.rb
@@ -1,7 +1,7 @@
 require "abbrev"
 require "optparse"
 require "time"
-require_relative "../common"
+require_relative "./common"
 
 actions = %w[create get update destroy]
 
@@ -29,15 +29,15 @@ unless ops
 end
 action = ops.last
 parser.parse(ARGV)
+case action
+when "create", "update"
+  args = JSON.parse(File.read(json_path)).merge(args)
+end
 
 service = @orca_api.new_medical_practice_service
 
-result = case action
-         when "get", "destroy"
-           service.send(action, args)
-         when "create", "update"
-           service.send(action, JSON.parse(File.read(json_path)).merge(args))
-         end
+result = process_medical_warnings(service, action, args)
+
 if result.ok?
   print_result(result)
 else

--- a/example/medical_practice_service/get_default.rb
+++ b/example/medical_practice_service/get_default.rb
@@ -1,10 +1,10 @@
 require "optparse"
-require_relative "../common"
+require_relative "./common"
 
 args = {
   "Diagnosis_Information" => {
     "Medical_Information" => {},
-  },
+  }
 }
 
 parser = OptionParser.new do |opts|
@@ -17,7 +17,7 @@ Usage: #{opts.program_name} <patient_id> <department_code> [options]
   opts.on("--perform-date 診療日付 YYYY-mm-dd形式。未指定ならばシステム日付", String) { |v| args["Perform_Date"] = v }
   opts.on("--doctors-fee 診察料区分 01:初診、02:再診、03:電話再診、09:診察料なし。未指定ならば病名などから診察料を返却する",
           String) { |v| args["Diagnosis_Information"]["Medical_Information"]["Doctors_Fee"] = v }
-  opts.on("--physician-Code ドクターコード", String) { |v| args["Diagnosis_Information"]["Physician_Code"] = v }
+  opts.on("--physician-code ドクターコード", String) { |v| args["Diagnosis_Information"]["Physician_Code"] = v }
 end
 
 parser.parse!(ARGV)
@@ -29,7 +29,7 @@ end
 
 service = @orca_api.new_medical_practice_service
 
-result = service.get_default(args)
+result = process_medical_warnings(service, :get_default, args)
 if result.ok?
   $stderr.puts "＊＊＊＊＊正常終了＊＊＊＊＊"
   $stderr.puts "標準出力に出力したJSONを適宜修正してファイルに保存してget_examination_fee.rbの引数に指定してください"
@@ -55,6 +55,9 @@ if result.ok?
         },
       },
     }
+    if args["Ignore_Medical_Warnings"]
+      hash["Ignore_Medical_Warnings"] = args["Ignore_Medical_Warnings"]
+    end
     puts JSON.pretty_generate(hash)
 
     if result["Medical_Information"].length > 1

--- a/example/medical_practice_service/get_examination_fee.rb
+++ b/example/medical_practice_service/get_examination_fee.rb
@@ -7,7 +7,7 @@ Usage:
   exit(1)
 end
 
-require_relative "../common"
+require_relative "./common"
 
 service = @orca_api.new_medical_practice_service
 
@@ -21,7 +21,7 @@ if (medical_info = medical_information["Medical_Info"])
   medical_information["Medication_Info"] = medical_info_0["Medication_Info"].first
 end
 
-result = service.get_examination_fee(args)
+result = process_medical_warnings(service, :get_examination_fee, args)
 if result.ok?
   $stderr.puts "＊＊＊＊＊正常終了＊＊＊＊＊"
   $stderr.puts "標準出力に出力したJSONを適宜修正してファイルに保存してcalc_medical_practice_fee.rbの引数に指定してください"

--- a/lib/orca_api/medical_practice_service.rb
+++ b/lib/orca_api/medical_practice_service.rb
@@ -73,6 +73,7 @@ module OrcaApi
   #
   # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori-overview.data/api21v03.pdf
   class MedicalPracticeService < Service
+    # 診療行為APIのレスポンスクラスの基底クラス
     class ResponseResult < ::OrcaApi::Result
       def initialize(raw, ignore_medical_warnings = nil)
         super(raw)
@@ -84,10 +85,10 @@ module OrcaApi
       end
 
       def ok?
-        if medical_warnings.length > 0
-          medical_warnings.any? { |i| !@ignore_medical_warnings.include?(i["Medical_Warning"]) } ? false : true
-        else
+        if medical_warnings.empty?
           super
+        else
+          medical_warnings.any? { |i| !@ignore_medical_warnings.include?(i["Medical_Warning"]) } ? false : true
         end
       end
     end
@@ -210,7 +211,9 @@ module OrcaApi
         "Request_Number" => "00",
         "Karte_Uid" => orca_api.karte_uid
       )
-      Response1Result.new(orca_api.call("/api21/medicalmodv31", body: { "medicalv3req1" => req }), ignore_medical_warnings(params))
+      Response1Result.new(
+        orca_api.call("/api21/medicalmodv31", body: { "medicalv3req1" => req }), ignore_medical_warnings(params)
+      )
     end
 
     # 診察料情報の取得
@@ -742,7 +745,9 @@ module OrcaApi
           "Diagnosis_Information" => params["Diagnosis_Information"],
         },
       }
-      Response1Result.new(orca_api.call("/api21/medicalmodv31", body: body), ignore_medical_warnings(params))
+      Response1Result.new(
+        orca_api.call("/api21/medicalmodv31", body: body), ignore_medical_warnings(params)
+      )
     end
 
     # 診療内容基本チェックAPI
@@ -769,6 +774,13 @@ module OrcaApi
           "Medical_OffTime" => res_body["Medical_OffTime"]
         }
       }
+      req = call_02_for_modify req, res_body, params
+      Response2Result.new(
+        orca_api.call("/api21/medicalmodv32", body: { "medicalv3req2" => req }), ignore_medical_warnings(params)
+      )
+    end
+
+    def call_02_for_modify(req, res_body, params)
       if res_body["Invoice_Number"]
         req["Perform_Time"] = params["Perform_Time"]
         req["Invoice_Number"] = res_body["Invoice_Number"]
@@ -777,7 +789,7 @@ module OrcaApi
           params["Diagnosis_Information"]["HealthInsurance_Information"]
         req["Diagnosis_Information"]["Medical_OffTime"] = params["Diagnosis_Information"]["Medical_Information"]["OffTime"]
       end
-      Response2Result.new(orca_api.call("/api21/medicalmodv32", body: { "medicalv3req2" => req }), ignore_medical_warnings(params))
+      req
     end
 
     # 診療確認API
@@ -804,7 +816,9 @@ module OrcaApi
       if answer
         req["Select_Answer"] = answer["Select_Answer"]
       end
-      Response2Result.new(orca_api.call("/api21/medicalmodv32", body: { "medicalv3req2" => req }), ignore_medical_warnings(params))
+      Response2Result.new(
+        orca_api.call("/api21/medicalmodv32", body: { "medicalv3req2" => req }), ignore_medical_warnings(params)
+      )
     end
 
     # 診療確認・請求確認API
@@ -836,7 +850,9 @@ module OrcaApi
       if params["Invoice_Number"]
         req["Patient_Mode"] = "Modify"
       end
-      Response3Result.new(orca_api.call("/api21/medicalmodv33", body: { "medicalv3req3" => req }), ignore_medical_warnings(params))
+      Response3Result.new(
+        orca_api.call("/api21/medicalmodv33", body: { "medicalv3req3" => req }), ignore_medical_warnings(params)
+      )
     end
 
     # 診療登録API
@@ -860,7 +876,9 @@ module OrcaApi
       if params["Invoice_Number"]
         req["Patient_Mode"] = "Modify"
       end
-      Response3Result.new(orca_api.call("/api21/medicalmodv33", body: { "medicalv3req3" => req }), ignore_medical_warnings(params))
+      Response3Result.new(
+        orca_api.call("/api21/medicalmodv33", body: { "medicalv3req3" => req }), ignore_medical_warnings(params)
+      )
     end
 
     # 診療行為訂正処理
@@ -881,7 +899,9 @@ module OrcaApi
           "Sequential_Number" => params["Sequential_Number"],
         },
       }
-      ResponseResult.new(orca_api.call("/api21/medicalmodv34", body: body), ignore_medical_warnings(params))
+      ResponseResult.new(
+        orca_api.call("/api21/medicalmodv34", body: body), ignore_medical_warnings(params)
+      )
     end
 
     # 診療行為削除処理

--- a/lib/orca_api/result.rb
+++ b/lib/orca_api/result.rb
@@ -83,6 +83,10 @@ module OrcaApi
       /\AW?0+\z/ =~ api_result ? true : false
     end
 
+    def warning?
+      /\AW/ =~ api_result ? true : false
+    end
+
     def locked?
       LOCKED_API_RESULT.include?(api_result)
     end


### PR DESCRIPTION
診療行為APIのレスポンスに警告コードが含まれている場合は、 `Result#ok?` が `false` を返すようにした

