### PR TITLE
患者基本情報取得のAPIを使うように変更した

### DIFF
--- a/lib/orca_api/patient_service.rb
+++ b/lib/orca_api/patient_service.rb
@@ -142,13 +142,21 @@ module OrcaApi
 
     # 患者情報の取得
     #
-    # @param id [String] 患者ID
+    # @param id [String]
+    #   患者ID
+    # @return [Result]
+    #   日レセからのレスポンス
+    # @see https://www.orca.med.or.jp/receipt/tec/api/patientget.html#response
     def get(id)
-      res = Result.new(call_01(id, nil, "Modify"))
-      if !res.locked?
-        unlock(res)
-      end
-      res
+      Result.new(
+        orca_api.call(
+          "/api01rv2/patientgetv2",
+          http_method: :get,
+          params: {
+            id: id
+          }
+        )
+      )
     end
 
     # 患者情報の更新

--- a/spec/orca_api/patient_service_get_spec.rb
+++ b/spec/orca_api/patient_service_get_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require_relative "shared_examples"
+
+RSpec.describe OrcaApi::PatientService, orca_api_mock: true do
+  let(:service) { described_class.new(orca_api) }
+
+  describe "#get" do
+    subject { service.get(patient_id) }
+
+    context "正常系" do
+      let(:patient_id) { "1234" }
+
+      before do
+        expect_data = [
+          {
+            path: "/api01rv2/patientgetv2",
+            params: {
+              id: patient_id
+            },
+            result: {
+              "patientinfores" => {
+                "Api_Result" => "00",
+                "Patient_Information" => {
+                  "Patient_ID" => patient_id
+                }
+              }
+            }.to_json,
+          }
+        ]
+        expect_orca_api_call(expect_data, binding)
+      end
+
+      its("ok?") { is_expected.to be true }
+    end
+
+    context "異常系" do
+      let(:patient_id) { "" }
+
+      before do
+        expect_data = [
+          {
+            path: "/api01rv2/patientgetv2",
+            params: {
+              id: ""
+            },
+            result: {
+              "patientinfores" => {
+                "Api_Result" => "01",
+                "Api_Result_Message" => "患者番号の設定がありません",
+              }
+            }.to_json,
+          }
+        ]
+        expect_orca_api_call(expect_data, binding)
+      end
+
+      its("ok?") { is_expected.to be false }
+    end
+  end
+end

--- a/spec/orca_api/patient_service_spec.rb
+++ b/spec/orca_api/patient_service_spec.rb
@@ -269,56 +269,6 @@ RSpec.describe OrcaApi::PatientService, orca_api_mock: true do
     end
   end
 
-  describe "#get" do
-    let(:patient_id) { 1 }
-    let(:response_json) { load_orca_api_response("orca12_patientmodv31_01_modify.json") }
-
-    subject { service.get(patient_id) }
-
-    context "正常系" do
-      before do
-        count = 0
-        prev_response_json = nil
-        expect(orca_api).to receive(:call).with(instance_of(String), body: instance_of(Hash)).exactly(2) { |path, body:|
-          count += 1
-          prev_response_json =
-            case count
-            when 1
-              expect_orca12_patientmodv31_01(path, body, patient_id, nil, "Modify", response_json)
-            when 2
-              expect_orca12_patientmodv31_99(path, body, prev_response_json)
-            end
-          prev_response_json
-        }
-      end
-
-      its("ok?") { is_expected.to be true }
-      its(:patient_information) { is_expected.to eq(response_data.first[1]["Patient_Information"]) }
-    end
-
-    context "異常系" do
-      let(:patient_id) { 2000 }
-      let(:response_json) { load_orca_api_response("orca12_patientmodv31_01_modify_E10.json") }
-
-      before do
-        count = 0
-        prev_response_json = nil
-        expect(orca_api).to receive(:call).with(instance_of(String), body: instance_of(Hash)).exactly(1) { |path, body:|
-          count += 1
-          prev_response_json =
-            case count
-            when 1
-              expect_orca12_patientmodv31_01(path, body, patient_id, nil, "Modify", response_json)
-            end
-          prev_response_json
-        }
-      end
-
-      its("ok?") { is_expected.to be false }
-      its(:patient_information) { is_expected.to eq(response_data.first[1]["Patient_Information"]) }
-    end
-  end
-
   describe "#update" do
     subject { service.update(*args) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,7 +124,7 @@ end
 #   呼び出し元のBindingオブジェクト。
 def expect_orca_api_call(expect_data, context)
   count = 0
-  expect(orca_api).to receive(:call).exactly(expect_data.length) do |path, params: {}, body: nil|
+  expect(orca_api).to receive(:call).exactly(expect_data.length) do |path, http_method: :post, params: {}, body: nil|
     expect_datum = expect_data[count]
     if expect_datum.key?(:path)
       expect(path).to eq(expect_datum[:path])
@@ -136,6 +136,10 @@ def expect_orca_api_call(expect_data, context)
 
     if expect_datum.key?(:body)
       expect_orca_api_call_body(body, expect_datum[:body], context)
+    end
+
+    if expect_datum.key?(:http_method)
+      expect(http_method).to eq expect_datum[:http_method]
     end
 
     count += 1


### PR DESCRIPTION
レスポンス内容を見ると、日レセAPIで代用できそう

* [HAORI](http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v031.pdf)
* [日レセAPI](https://www.orca.med.or.jp/receipt/tec/api/patientget.html#response)
