### PR TITLE
チェック用個別レセ電データ取得

### DIFF
--- a/example/receipt_data_check_service/create.rb
+++ b/example/receipt_data_check_service/create.rb
@@ -1,0 +1,72 @@
+require "optparse"
+require_relative "../common"
+
+args = {}
+parser = OptionParser.new do |opts|
+  opts.banner = <<-EOS
+Usage: #{opts.program_name} <submission_mode> <patient_id> <patient_perform_month> <paient_in_out> [options]
+         submission_mode: 提出先
+                          医保　02:社保 03:国保 04:広域
+                          労災　05
+         patient_id: 対象患者番号
+         patient_perform_month: 診療年月 YYYY-mm
+         patient_in_out: 入外区分
+                         I:入院 O:入院外 IO、OI:入院、入院外
+  EOS
+  opts.on("--perform-date 実施年月日 YYYY-mm", String) { |v| args["Perform_Date"] = v }
+  opts.on("--perform-month 診療年月 YYYY-mm", String) { |v| args["Perform_Month"] = v }
+  opts.on("--ac-date 請求年月日 YYYY-mm-dd", String) { |v| args["Ac_Date"] = v }
+  opts.on("--create-mode 作成モード", String) { |v| args["Create_Mode"] = v }
+  opts.on("--check-mode レセ電データチェック Yes:チェックする Yes以外:チェックしない", String) { |v| args["Check_Mode"] = v }
+  opts.on("--insurance-provider-number 直接請求する保険者番号", String) { |v| args["InsuranceProvider_Number"] = v }
+  opts.on("--start-month 期間指定(開始年月)  YYYY-mm", String) { |v| args["Start_Month"] = v }
+  opts.on("--end-month 期間指定(終了年月)  YYYY-mm", String) { |v| args["End_Month"] = v }
+end
+
+parser.parse!(ARGV)
+args["Submission_Mode"] = ARGV.shift
+args["Patient_Information"] = [
+  {
+    "Patient_ID" => ARGV.shift,
+    "Patient_Perform_Month" => ARGV.shift,
+    "Patient_InOut" => ARGV.shift,
+  }
+]
+
+service = @orca_api.new_receipt_data_check_service
+result = service.create(args)
+if result.ok?
+  print_result(result)
+else
+  error(result)
+  exit
+end
+
+data_id_information = result["Data_Id_Information"]
+
+args["Orca_Uid"] = result.orca_uid
+while (result = service.created(args)).doing?
+  print_result(result)
+  sleep(1)
+end
+
+if result.ok?
+  print_result(result)
+else
+  error(result)
+end
+
+puts "＊＊＊＊＊ＩＤ一覧＊＊＊＊＊"
+pp data_id_information
+__END__
+# 必要に応じてORCA_API_URIを設定した上で下記のように実行する
+
+$ bundle exec ruby example/receipt_data_check_service/create.rb 02 00713 2019-03 IO --perform-month 2019-03 --start 2018-10 --end 9999-99
+
+...
+
+＊＊＊＊＊ＩＤ一覧＊＊＊＊＊
+[{"Data_Id"=>"846dd527-e7cb-4789-8a2c-2a25efdad6b3",
+  "Print_Id"=>"1605c6e3-425f-48be-80b3-1929f250377f"}]
+
+$ curl http://your-orca-host/blobapi/846dd527-e7cb-4789-8a2c-2a25efdad6b3 -o test.uke

--- a/example/receipt_data_check_service/list_effective_information.rb
+++ b/example/receipt_data_check_service/list_effective_information.rb
@@ -1,0 +1,31 @@
+if ![2].include?(ARGV.length)
+  $stderr.puts(<<-EOS)
+Usage:
+  #{File.basename(__FILE__)} perform_month submission_mode
+    perform_month: YYYY-mm
+    submission_mode: 医保の場合 02:社保 03:国保 04:広域。労災の場合 05。
+  EOS
+  exit(1)
+end
+
+require_relative "../common"
+
+perform_month = ARGV.shift
+submission_mode = ARGV.shift
+
+service = @orca_api.new_receipt_data_check_service
+result = service.list_effective_information(
+  Perform_Month: perform_month,
+  Submission_Mode: submission_mode
+)
+if result.ok?
+  print_result(result)
+else
+  error(result)
+  exit
+end
+__END__
+
+# 必要に応じてORCA_API_URIを設定した上で下記のように実行する
+
+$ bundle exec ruby example/receipt_data_check_service/list_effective_information.rb 2019-02 02

--- a/lib/orca_api/client.rb
+++ b/lib/orca_api/client.rb
@@ -177,6 +177,12 @@ module OrcaApi #:nodoc:
     # @!method new_image_service
     # @return [ImageService] ImageServiceインスタンス
 
+    # @!method new_receipt_data_check_service
+    # @return [ReceiptDataCheckService] ReceiptDataCheckServiceインスタンス
+
+    # @!method new_receipt_data_service
+    # @return [ReceiptDataService] ReceiptDataServiceインスタンス
+
     # @!method new_receipt_service
     # @return [ReceiptService] ReceiptServiceインスタンス
 
@@ -218,6 +224,7 @@ module OrcaApi #:nodoc:
       PatientService
       PhysicianService
       PrintService
+      ReceiptDataCheckService
       ReceiptDataService
       ReceiptService
       RehabilitationCommentService

--- a/lib/orca_api/receipt_data_check_service.rb
+++ b/lib/orca_api/receipt_data_check_service.rb
@@ -12,7 +12,6 @@ module OrcaApi
   #
   # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_receiptdata_check
   class ReceiptDataCheckService < Service
-
     # 医保分のレセ電データ作成時に必要な情報取得する処理の結果を表現するクラス
     class ListEffectiveInformationResult < ::OrcaApi::Result
       def body

--- a/lib/orca_api/receipt_data_check_service.rb
+++ b/lib/orca_api/receipt_data_check_service.rb
@@ -1,0 +1,136 @@
+require_relative "service"
+
+module OrcaApi
+  # チェック用個別レセ電データ取得
+  #
+  # レセ電データ取得(一括)の流れと同様
+  #
+  #  1. 医保分のレセ電データ作成時に必要な次の情報取得する: list_effective_information
+  #  2. 処理実施: create
+  #  3. 処理確認: created
+  #  4. 大容量データAPIでレセ電データ(CSV)の取得
+  #
+  # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_receiptdata_check
+  class ReceiptDataCheckService < Service
+
+    # 医保分のレセ電データ作成時に必要な情報取得する処理の結果を表現するクラス
+    class ListEffectiveInformationResult < ::OrcaApi::Result
+      def body
+        @body ||= {
+          "Effective_Period_Information" => [],
+          "InsuranceProvider_Information" => [],
+        }.merge(self.class.parse(@raw))
+      end
+    end
+
+    # 処理確認の結果を扱うクラス
+    class CreatedResult < ::OrcaApi::Result
+      # 処理中かどうか
+      #
+      # @return [Boolean] 処理中であればtrue、そうでなければfalse。
+      def doing?
+        api_result == "E70"
+      end
+    end
+
+    # 医保分のレセ電データ作成時に必要な情報取得する
+    # @param [Hash] args
+    #   * Submission_Mode (String)
+    #     提出先。
+    #     医保の場合、02:社保 03:国保 04:広域。労災の場合05。
+    #     必須。
+    #   * Perform_Date (String)
+    #     実施年月日。YYYY-mm-dd形式。省略した場合は現在年月日。
+    #   * Perform_Month (String)
+    #     診療年月。YYYY-mm形式。省略した場合は現在年月。
+    #   * Ac_Date (String)
+    #     請求年月日。YYYY-mm-dd形式。省略した場合は現在年月日。
+    #   * Create_Mode (String)
+    #     作成モード。Check:点検用 Check以外:提出用。
+    # @return [OrcaApi::ReceiptDataCheckService::ListEffectiveInformationResult]
+    #   日レセからのレスポンス
+    def list_effective_information(args)
+      req = default_request.merge(args).merge(
+        "Request_Number" => "00",
+        "Karte_Uid" => orca_api.karte_uid
+      )
+      call(req, ListEffectiveInformationResult)
+    end
+
+    # 処理実施
+    #
+    # @param [Hash] args
+    #   * Submission_Mode (String)
+    #     提出先。
+    #     医保の場合、02:社保 03:国保 04:広域。労災の場合05。
+    #     必須。
+    #   * Perform_Date (String)
+    #     実施年月日。YYYY-mm-dd形式。省略した場合は現在年月日。
+    #   * Perform_Month (String)
+    #     診療年月。YYYY-mm形式。省略した場合は現在年月。
+    #   * Ac_Date (String)
+    #     請求年月日。YYYY-mm-dd形式。省略した場合は現在年月日。
+    #   * Create_Mode (String)
+    #     作成モード。Check:点検用 Check以外:提出用。
+    #   * Check_Mode (String)
+    #     レセ電データチェック Yes:チェックする Yes以外:チェックしない。省略した場合は「チェックしない」。
+    #   * InsuranceProvider_Number (String)
+    #     直接請求する保険者番号
+    #   * Start_Month (String)
+    #     期間指定(開始年月)。YYYY-mm形式。
+    #   * End_Month (String)
+    #     期間指定(終了年月)。YYYY-mm形式。
+    #   * Patient_Information (Array<Hash>)
+    #     個別対象患者一覧。個別作成のとき必須。配列の最大サイズは100。
+    #     配列の内容は以下のHash。
+    #     * Patient_ID (String)
+    #       患者番号
+    #     * Patient_Perfrm_Month (String)
+    #       診療年月
+    #     * Patient_InOut (String)
+    #       入外区分 I:入院 O:入院外 IO、OI:入院、入院外
+    # @return [OrcaApi::Result]
+    #   日レセからのレスポンス
+    def create(args)
+      req = default_request.merge(args).merge(
+        "Request_Number" => "01",
+        "Karte_Uid" => orca_api.karte_uid
+      )
+      call(req)
+    end
+
+    # 処理確認
+    #
+    # @param [Hash] args
+    #   `#create` の `args` に以下を追加したもの
+    #   * Orca_Uid (String)
+    #     オルカＵＩＤ。必須。
+    # @return [OrcaApi::ReceiptDataService::CreatedResult]
+    #   日レセからのレスポンス
+    def created(args)
+      req = default_request.merge(args).merge(
+        "Request_Number" => "02",
+        "Karte_Uid" => orca_api.karte_uid
+      )
+      call(req, CreatedResult)
+    end
+
+    private
+
+    def default_request
+      now = Time.now
+      {
+        "Perform_Date" => now.strftime("%Y-%m-%d"),
+        "Perform_Month" => now.strftime("%Y-%m"),
+        "Ac_Date" => now.strftime("%Y-%m-%d"),
+        "Create_Mode" => "Check",
+        "InOut" => "IO",
+        "Check_Mode" => "No",
+      }
+    end
+
+    def call(req, result_class = Result)
+      result_class.new(orca_api.call("/orca44/receiptdatacheckmakev3", body: { "receiptdata_check_makev3req" => req }))
+    end
+  end
+end

--- a/lib/orca_api/receipt_data_check_service.rb
+++ b/lib/orca_api/receipt_data_check_service.rb
@@ -105,7 +105,7 @@ module OrcaApi
     #   `#create` の `args` に以下を追加したもの
     #   * Orca_Uid (String)
     #     オルカＵＩＤ。必須。
-    # @return [OrcaApi::ReceiptDataService::CreatedResult]
+    # @return [OrcaApi::ReceiptDataCheckService::CreatedResult]
     #   日レセからのレスポンス
     def created(args)
       req = default_request.merge(args).merge(

--- a/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_00.json
+++ b/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_00.json
@@ -1,0 +1,50 @@
+{
+  "receiptdata_check_makev3res": {
+    "Request_Number": "00",
+    "Response_Number": "01",
+    "Karte_Uid": "94e16fd4-4664-49cf-9be0-0af44ac25d4a",
+    "Information_Date": "2019-04-08",
+    "Information_Time": "16:14:16",
+    "Api_Result": "000",
+    "Api_Result_Message": "情報取得終了",
+    "Reskey": "Acceptance_Info",
+    "Submission_Mode": "02",
+    "Perform_Month": "2019-03",
+    "Effective_Period_Information": [
+      {
+        "Info_Period_Start_Month": "2018-10",
+        "Info_Period_End_Month": "9999-99"
+      },
+      {
+        "Info_Period_Start_Month": "0000-00",
+        "Info_Period_End_Month": "2018-09"
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ],
+    "InsuranceProvider_Information": [
+      {
+        "Info_InsuranceProvider_Number": "00000000",
+        "Info_InsuranceProvider_Name": "直接請求する保険者以外"
+      },
+      {
+        "Info_InsuranceProvider_Number": "06130702",
+        "Info_InsuranceProvider_Name": "みずほ健保組合"
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  }
+}

--- a/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_00_empty.json
+++ b/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_00_empty.json
@@ -1,0 +1,24 @@
+{
+  "receiptdata_check_makev3res": {
+    "Request_Number": "00",
+    "Response_Number": "01",
+    "Karte_Uid": "94e16fd4-4664-49cf-9be0-0af44ac25d4a",
+    "Information_Date": "2019-04-08",
+    "Information_Time": "18:30:35",
+    "Api_Result": "000",
+    "Api_Result_Message": "情報取得終了",
+    "Reskey": "Acceptance_Info",
+    "Submission_Mode": "02",
+    "Perform_Month": "2019-03",
+    "Receiptdata_Warning_Info": [
+      {
+        "Receiptdata_Warning": "W04",
+        "Receiptdata_Warning_Message": "返却情報はありません"
+      },
+      {},
+      {},
+      {},
+      {}
+    ]
+  }
+}

--- a/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_01.json
+++ b/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_01.json
@@ -1,0 +1,32 @@
+{
+  "receiptdata_check_makev3res": {
+    "Request_Number": "01",
+    "Response_Number": "02",
+    "Karte_Uid": "94e16fd4-4664-49cf-9be0-0af44ac25d4a",
+    "Orca_Uid": "43d0b315-7ca7-497a-84e8-bdd4c007acfe",
+    "Information_Date": "2019-04-08",
+    "Information_Time": "17:02:21",
+    "Api_Result": "000",
+    "Api_Result_Message": "処理実施終了",
+    "Reskey": "Acceptance_Info",
+    "Submission_Mode": "02",
+    "Perform_Month": "2019-03",
+    "Start_Month": "2018-10",
+    "End_Month": "9999-99",
+    "Data_Id_Information": [
+      {
+        "Data_Id": "c16557c8-2855-49a4-a174-968f1610ddce",
+        "Print_Id": "fd9a880c-e9d3-448f-9edb-e88d3c456d5c"
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  }
+}

--- a/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_02.json
+++ b/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_02.json
@@ -1,0 +1,19 @@
+{
+  "receiptdata_check_makev3res": {
+    "Request_Number": "02",
+    "Response_Number": "02",
+    "Karte_Uid": "94e16fd4-4664-49cf-9be0-0af44ac25d4a",
+    "Orca_Uid": "43d0b315-7ca7-497a-84e8-bdd4c007acfe",
+    "Information_Date": "2019-04-08",
+    "Information_Time": "17:11:31",
+    "Api_Result": "000",
+    "Api_Result_Message": "処理確認終了",
+    "Reskey": "Acceptance_Info",
+    "Submission_Mode": "02",
+    "Perform_Month": "2019-03",
+    "Start_Month": "2018-10",
+    "End_Month": "9999-99",
+    "All_Count": "00001",
+    "All_Number_Of_Sheets": "00000"
+  }
+}

--- a/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_02_E70.json
+++ b/spec/fixtures/orca_api_responses/orca44_receiptdatacheckmakev3_02_E70.json
@@ -1,0 +1,17 @@
+{
+  "receiptdata_check_makev3res": {
+    "Request_Number": "02",
+    "Response_Number": "02",
+    "Karte_Uid": "94e16fd4-4664-49cf-9be0-0af44ac25d4a",
+    "Orca_Uid": "43d0b315-7ca7-497a-84e8-bdd4c007acfe",
+    "Information_Date": "2019-04-08",
+    "Information_Time": "17:11:31",
+    "Api_Result": "E70",
+    "Api_Result_Message": "処理中です【帳票印刷処理】",
+    "Reskey": "Acceptance_Info",
+    "Submission_Mode": "02",
+    "Perform_Month": "2019-03",
+    "Start_Month": "2018-10",
+    "End_Month": "9999-99"
+  }
+}

--- a/spec/orca_api/income_service_spec.rb
+++ b/spec/orca_api/income_service_spec.rb
@@ -682,7 +682,7 @@ RSpec.describe OrcaApi::IncomeService, orca_api_mock: true do
           "Patient_ID" => "1",
           "InOut" => "O",
           "Invoice_Number" => "13",
-          "Print_Information" =>  {
+          "Print_Information" => {
             "Print_Invoice_Receipt_Class" => "1",
             "Print_Statement_Class" => "1"
           }

--- a/spec/orca_api/receipt_data_check_service_spec.rb
+++ b/spec/orca_api/receipt_data_check_service_spec.rb
@@ -1,0 +1,153 @@
+require "spec_helper"
+require_relative "shared_examples"
+
+RSpec.describe OrcaApi::ReceiptDataCheckService, orca_api_mock: true do
+  let(:service) { described_class.new(orca_api) }
+  let(:now) { Time.now }
+
+  def default_request
+    {
+      "Perform_Date" => now.strftime("%Y-%m-%d"),
+      "Perform_Month" => now.strftime("%Y-%m"),
+      "Ac_Date" => now.strftime("%Y-%m-%d"),
+      "Create_Mode" => "Check",
+      "InOut" => "IO",
+      "Check_Mode" => "No",
+    }
+  end
+
+  describe "#list_effective_information" do
+    context "正常系" do
+      it "医保分のレセ電データ作成時に必要な情報取得できること" do
+        perform_month = "2019-03"
+        submission_mode = "02"
+
+        expect_data = [
+          {
+            path: "/orca44/receiptdatacheckmakev3",
+            body: {
+              "=receiptdata_check_makev3req" => default_request.merge(
+                "Request_Number" => "00",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Perform_Month" => perform_month,
+                "Submission_Mode" => submission_mode,
+                "InOut" => "IO"
+              )
+            },
+            result: "orca44_receiptdatacheckmakev3_00.json",
+          },
+        ]
+
+        expect_orca_api_call(expect_data, binding)
+
+        Timecop.freeze(now) do
+          result = service.list_effective_information({
+                                                        "Perform_Month" => perform_month,
+                                                        "Submission_Mode" => submission_mode
+                                                      })
+          expect(result.ok?).to be true
+        end
+      end
+
+      it "該当する情報がない場合は空の配列を返すこと" do
+        perform_month = "2019-03"
+        submission_mode = "02"
+
+        expect_data = [
+          {
+            path: "/orca44/receiptdatacheckmakev3",
+            body: {
+              "=receiptdata_check_makev3req" => default_request.merge(
+                "Request_Number" => "00",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Perform_Month" => perform_month,
+                "Submission_Mode" => submission_mode,
+                "InOut" => "IO"
+              )
+            },
+            result: "orca44_receiptdatacheckmakev3_00_empty.json",
+          },
+        ]
+
+        expect_orca_api_call(expect_data, binding)
+
+        Timecop.freeze(now) do
+          result = service.list_effective_information({
+                                                        "Perform_Month" => perform_month,
+                                                        "Submission_Mode" => submission_mode
+                                                      })
+          expect(result.ok?).to be true
+          expect(result["Effective_Period_Information"]).to eq([])
+          expect(result.effective_period_information).to eq([])
+          expect(result["InsuranceProvider_Information"]).to eq([])
+          expect(result.insurance_provider_information).to eq([])
+        end
+      end
+    end
+  end
+
+  describe "チェック用個別レセ電データ取得" do
+    context "正常系" do
+      it "レセ電データのUIDを取得できること" do
+        args = {
+          "Perform_Month" => "2019-03",
+          "Submission_Mode" => "02",
+        }
+
+        expect_data = [
+          {
+            path: "/orca44/receiptdatacheckmakev3",
+            body: {
+              "=receiptdata_check_makev3req" => default_request.merge(args).merge(
+                "Request_Number" => "01",
+                "Karte_Uid" => orca_api.karte_uid
+              ),
+            },
+            result: "orca44_receiptdatacheckmakev3_01.json",
+          },
+          {
+            path: "/orca44/receiptdatacheckmakev3",
+            body: {
+              "=receiptdata_check_makev3req" => default_request.merge(args).merge(
+                "Request_Number" => "02",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Orca_Uid" => "`prev.orca_uid`"
+              ),
+            },
+            result: "orca44_receiptdatacheckmakev3_02_E70.json",
+          },
+          {
+            path: "/orca44/receiptdatacheckmakev3",
+            body: {
+              "=receiptdata_check_makev3req" => default_request.merge(args).merge(
+                "Request_Number" => "02",
+                "Karte_Uid" => orca_api.karte_uid,
+                "Orca_Uid" => "`prev.orca_uid`"
+              ),
+            },
+            result: "orca44_receiptdatacheckmakev3_02.json",
+          },
+        ]
+
+        expect_orca_api_call(expect_data, binding)
+
+        Timecop.freeze(now) do
+          result = service.create(args)
+          expect(result.ok?).to be true
+
+          data = parse_json(load_orca_api_response("orca44_receiptdatacheckmakev3_01.json"))
+          expect(result["Data_Id_Information"]).to eq data.first[1]["Data_Id_Information"]
+
+          args["Orca_Uid"] = result.orca_uid
+          result = service.created(args)
+          expect(result.doing?).to be true
+          expect(result.ok?).to be false
+
+          result = service.created(args)
+          expect(result.doing?).to be false
+          expect(result.ok?).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
チェック用個別レセ電データ取得（orca44_receiptdatacheckmakev3）の実装

https://www.orcamo.co.jp/api-council/members/standards/?haori_receiptdata_check
