### PR TITLE
[WIP] ロックをかけずに保険情報取得できるようにした

### DIFF
--- a/example/patient_service/health_public_insurance/get_without_lock.rb
+++ b/example/patient_service/health_public_insurance/get_without_lock.rb
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+require_relative "../../common"
+
+patient_service = @orca_api.new_patient_service
+
+result = patient_service.get_health_public_insurance(ARGV.shift, false)
+if result.ok?
+  pp result.patient_information
+  pp result.health_public_insurance
+else
+  error(result)
+end

--- a/lib/orca_api/patient_service/health_public_insurance_common.rb
+++ b/lib/orca_api/patient_service/health_public_insurance_common.rb
@@ -187,7 +187,6 @@ module OrcaApi
       def call_00(id)
         req = {
           "Request_Number" => "00",
-          "Karte_Uid" => orca_api.karte_uid,
           "Patient_Information" => {
             "Patient_ID" => id.to_s,
           }

--- a/lib/orca_api/patient_service/health_public_insurance_common.rb
+++ b/lib/orca_api/patient_service/health_public_insurance_common.rb
@@ -46,12 +46,15 @@ module OrcaApi
       #
       # @param [String] id
       #   患者ID
+      # @param [Boolean] with_lock (optional)
+      #   ロック利用、未設定時はtrue
       # @return [Result]
       #   日レセからのレスポンス
       #
-      # @see http://cms-edit.orca.med.or.jp/_admin/preview_revision/18351#api2
+      # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod#api2
       # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032.pdf
       # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032_err.pdf
+      # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod_search
       def get(id, with_lock = true)
         if with_lock
           res = call_01(id)

--- a/lib/orca_api/patient_service/health_public_insurance_common.rb
+++ b/lib/orca_api/patient_service/health_public_insurance_common.rb
@@ -52,10 +52,14 @@ module OrcaApi
       # @see http://cms-edit.orca.med.or.jp/_admin/preview_revision/18351#api2
       # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032.pdf
       # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032_err.pdf
-      def get(id)
-        res = call_01(id)
-        unlock(res)
-        res
+      def get(id, with_lock = true)
+        if with_lock
+          res = call_01(id)
+          unlock(res)
+          res
+        else
+          call_00(id)
+        end
       end
 
       # 患者保険・公費情報を更新する
@@ -176,6 +180,17 @@ module OrcaApi
       end
 
       private
+
+      def call_00(id)
+        req = {
+          "Request_Number" => "00",
+          "Karte_Uid" => orca_api.karte_uid,
+          "Patient_Information" => {
+            "Patient_ID" => id.to_s,
+          }
+        }
+        call(req)
+      end
 
       def call_01(id)
         req = {

--- a/spec/orca_api/patient_service/health_public_insurance_spec.rb
+++ b/spec/orca_api/patient_service/health_public_insurance_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe OrcaApi::PatientService::HealthPublicInsurance, orca_api_mock: tr
             body: {
               "=patientmodv3req2" => {
                 "Request_Number" => "00",
-                "Karte_Uid" => orca_api.karte_uid,
                 "Patient_Information" => {
                   "Patient_ID" => "1",
                 }
@@ -105,7 +104,6 @@ RSpec.describe OrcaApi::PatientService::HealthPublicInsurance, orca_api_mock: tr
             body: {
               "=patientmodv3req2" => {
                 "Request_Number" => "00",
-                "Karte_Uid" => orca_api.karte_uid,
                 "Patient_Information" => {
                   "Patient_ID" => "1",
                 }


### PR DESCRIPTION
患者保険情報登録処理(URL:/orca12/patientmodv32)で、getメソッドに引数を追加してRequest_Number=00に対応しました。

ref. https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod_search