### PR TITLE
ロックをかけずに保険情報取得できるようにした

### DIFF
--- a/example/patient_service/health_public_insurance/fetch.rb
+++ b/example/patient_service/health_public_insurance/fetch.rb
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+require_relative "../../common"
+
+patient_service = @orca_api.new_patient_service
+
+result = patient_service.fetch_health_public_insurance(ARGV.shift)
+if result.ok?
+  pp result.patient_information
+  pp result.health_public_insurance
+else
+  error(result)
+end

--- a/lib/orca_api/patient_service.rb
+++ b/lib/orca_api/patient_service.rb
@@ -233,6 +233,9 @@ module OrcaApi
     # @!method get_health_insurance
     #   @see PatientService::HealthInsurance#get
 
+    # @!method fetch_health_insurance
+    #   @see PatientService::HealthInsurance#fetch
+
     # @!method update_health_insurance
     #   @see PatientService::HealthInsurance#update
 
@@ -330,7 +333,7 @@ module OrcaApi
       require_relative "patient_service/#{method_suffix}"
       klass = const_get(class_name)
 
-      method_names = klass.instance_methods & (klass.instance_methods(false) + %i(get update)).uniq
+      method_names = klass.instance_methods & (klass.instance_methods(false) + %i(get update fetch)).uniq
       method_names.each do |method_name|
         define_method("#{method_name}_#{method_suffix}") do |*args|
           klass.new(orca_api).send(method_name, *args)

--- a/lib/orca_api/patient_service/health_public_insurance_common.rb
+++ b/lib/orca_api/patient_service/health_public_insurance_common.rb
@@ -49,13 +49,25 @@ module OrcaApi
       # @return [Result]
       #   日レセからのレスポンス
       #
-      # @see http://cms-edit.orca.med.or.jp/_admin/preview_revision/18351#api2
+      # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod#api2
       # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032.pdf
       # @see http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032_err.pdf
       def get(id)
         res = call_01(id)
         unlock(res)
         res
+      end
+
+      # 患者保険・公費情報を取得する(ロックなし)
+      #
+      # @param [String] id
+      #   患者ID
+      # @return [Result]
+      #   日レセからのレスポンス
+      #
+      # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod_search
+      def fetch(id)
+        call_00(id)
       end
 
       # 患者保険・公費情報を更新する
@@ -176,6 +188,16 @@ module OrcaApi
       end
 
       private
+
+      def call_00(id)
+        req = {
+          "Request_Number" => "00",
+          "Patient_Information" => {
+            "Patient_ID" => id.to_s,
+          }
+        }
+        call(req)
+      end
 
       def call_01(id)
         req = {

--- a/spec/orca_api/patient_service/health_public_insurance_spec.rb
+++ b/spec/orca_api/patient_service/health_public_insurance_spec.rb
@@ -72,6 +72,60 @@ RSpec.describe OrcaApi::PatientService::HealthPublicInsurance, orca_api_mock: tr
     end
   end
 
+  describe "#fetch" do
+    subject { service.fetch(patient_id) }
+
+    context "正常系" do
+      it "works" do
+        expect_data = [
+          {
+            path: "/orca12/patientmodv32",
+            body: {
+              "=patientmodv3req2" => {
+                "Request_Number" => "00",
+                "Patient_Information" => {
+                  "Patient_ID" => "1",
+                }
+              }
+            },
+            result: "orca12_patientmodv32_01.json",
+          }
+        ]
+
+        expect_orca_api_call(expect_data, binding)
+
+        result = service.fetch(1)
+
+        expect(result.ok?).to be true
+      end
+    end
+
+    context "異常系" do
+      it "works" do
+        expect_data = [
+          {
+            path: "/orca12/patientmodv32",
+            body: {
+              "=patientmodv3req2" => {
+                "Request_Number" => "00",
+                "Patient_Information" => {
+                  "Patient_ID" => "1",
+                }
+              }
+            },
+            result: "orca12_patientmodv32_01_E10.json",
+          },
+        ]
+
+        expect_orca_api_call(expect_data, binding)
+
+        result = service.fetch(1)
+
+        expect(result.ok?).to be false
+      end
+    end
+  end
+
   describe "#update" do
     context "正常系" do
       it "患者保険・公費を登録する(New)" do


### PR DESCRIPTION
患者保険情報登録処理(URL:/orca12/patientmodv32)で、fetchメソッドを新設してRequest_Number=00に対応しました。

ref. https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod_search

もともとhttps://github.com/orca-api/orca-api/pull/25 でgetメソッドに引数を追加して対応していましたが、 https://github.com/orca-api/orca-api/pull/26 とメソッド名を揃えました。

