### PR TITLE
足りないrequireメソッド呼び出しを追加

### DIFF
--- a/lib/orca_api/result.rb
+++ b/lib/orca_api/result.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module OrcaApi
   # 日レセAPIの呼び出し結果を扱うクラス
   class Result


### PR DESCRIPTION
アプリケーションでの明示的な `require "set"` なしに動作できるようにするpull-requestです．

## pull-request前

```
yuya@yoshiyuki|23:14:04|0% git rev-parse HEAD
bc829d1a2dceecfa9f2c6a99e9c9a5be7c41b392
yuya@yoshiyuki|23:12:42|0% ruby -Ilib -rset -rorca_api -e ''
<出力なし：期待通り>
yuya@yoshiyuki|23:14:02|0% ruby -Ilib -rorca_api -e ''
Traceback (most recent call last):
        9: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        8: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        7: from /home/yuya/src/github.com/orca-api/orca-api/lib/orca_api.rb:2:in `<top (required)>'
        6: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        5: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        4: from /home/yuya/src/github.com/orca-api/orca-api/lib/orca_api/client.rb:6:in `<top (required)>'
        3: from /home/yuya/src/github.com/orca-api/orca-api/lib/orca_api/client.rb:6:in `require_relative'
        2: from /home/yuya/src/github.com/orca-api/orca-api/lib/orca_api/result.rb:1:in `<top (required)>'
        1: from /home/yuya/src/github.com/orca-api/orca-api/lib/orca_api/result.rb:3:in `<module:OrcaApi>'
/home/yuya/src/github.com/orca-api/orca-api/lib/orca_api/result.rb:4:in `<class:Result>': uninitialized constant OrcaApi::Result::Set (NameError)
Did you mean?  Net
```

## pull-request後

```
yuya@yoshiyuki|23:25:18|0% ruby -Ilib -rorca_api -e ''
<出力なし：期待通り>
```
