### PR TITLE
症状詳記コメント取得の労災アフターケア対応

### DIFF
--- a/lib/orca_api/subjective_service.rb
+++ b/lib/orca_api/subjective_service.rb
@@ -79,6 +79,11 @@ module OrcaApi
     ].freeze
     private_constant :LIST_PARAMS
 
+    COMMENT_PARAMS = [
+      "Perform_Day"
+    ].freeze
+    private_constant :COMMENT_PARAMS
+
     # 症状詳記登録
     def create(params)
       Result.new(
@@ -160,7 +165,7 @@ module OrcaApi
               "Insurance_Combination_Number" => info["HealthInsurance_Information"]["Insurance_Combination_Number"],
               "Subjectives_Detail_Record" => info["Subjectives_Detail_Record"],
               "Subjectives_Number" => info["Subjectives_Number"]
-            }
+            }.merge(shaper(info, COMMENT_PARAMS))
           }
         )
       )

--- a/spec/orca_api/subjective_service_spec.rb
+++ b/spec/orca_api/subjective_service_spec.rb
@@ -267,6 +267,16 @@ RSpec.describe OrcaApi::SubjectiveService, orca_api_mock: true do
                     },
                     "Subjectives_Detail_Record" => "08",
                     "Subjectives_Number" => "01"
+                  },
+                  {
+                    "InOut" => "O",
+                    "Department_Code" => "00",
+                    "HealthInsurance_Information" => {
+                      "Insurance_Combination_Number" => "0002"
+                    },
+                    "Perform_Day" => "20",
+                    "Subjectives_Detail_Record" => "03",
+                    "Subjectives_Number" => "01"
                   }
                 ]
               }
@@ -317,6 +327,30 @@ RSpec.describe OrcaApi::SubjectiveService, orca_api_mock: true do
                 }
               }
             }.to_json
+          },
+          {
+            path: "/api01rv2/subjectiveslstv2",
+            body: {
+              "subjectiveslstreq" => {
+                "Request_Number" => "02",
+                "InOut" => "O",
+                "Patient_ID" => "00001",
+                "Perform_Date" => "2018-06",
+                "Department_Code" => "00",
+                "Insurance_Combination_Number" => "0002",
+                "Subjectives_Detail_Record" => "03",
+                "Subjectives_Number" => "01",
+                "Perform_Day" => "20"
+              }
+            },
+            response: {
+              "subjectiveslstres" => {
+                "Api_Result" => "000",
+                "Subjectives_Code_Information" => {
+                  "Subjectives_Code" => "うゐのおくやまけふこえて"
+                }
+              }
+            }.to_json
           }
         ],
         binding
@@ -348,6 +382,17 @@ RSpec.describe OrcaApi::SubjectiveService, orca_api_mock: true do
                                                        "Subjectives_Detail_Record" => "08",
                                                        "Subjectives_Number" => "01",
                                                        "Subjectives_Code" => "わかよたれそつねならむ",
+                                                     },
+                                                     {
+                                                       "InOut" => "O",
+                                                       "Department_Code" => "00",
+                                                       "HealthInsurance_Information" => {
+                                                         "Insurance_Combination_Number" => "0002"
+                                                       },
+                                                       "Perform_Day" => "20",
+                                                       "Subjectives_Detail_Record" => "03",
+                                                       "Subjectives_Number" => "01",
+                                                       "Subjectives_Code" => "うゐのおくやまけふこえて",
                                                      }
                                                    ])
     end


### PR DESCRIPTION
概要
=
他の症状詳記と異なり、アフターケアの症状詳記は受診日の単位で登録を実施する必要がある。

上記の仕様上、症状詳記コメントにおいても受診日の単位で管理される事になるのだが、
コメント取得時のパラメータに受診日（Perform_Day）が含まれておらず、同一年月に複数回の受診 及び 症状詳記のコメントを実施された際に、コメントを正しく取得できない状態になっていた。

### haori からのレスポンス抜粋
```
<Api_Result type="string">WK3</Api_Result>
<Api_Result_Message type="string">対象が複数あります。最初のコメントのみ返却します。</Api_Result_Message>
```

call02 のリクエストパラメータに受診日を加える（＊）ことで、call01 の取得結果（症状詳記一覧）と call02 の取得結果（症状詳記コメント）を正しく紐付けてレスポンスするように変更しました。

### ＊
Perform_Day は「アフターケア」の場合に限定して、call01 の取得結果に含まれる為、
存在しない可能性を考慮しています。

### haori 仕様抜粋
![image](https://user-images.githubusercontent.com/54239938/83428302-1a6d9080-a46d-11ea-9ad8-bbdbd8d5aea1.png)

### 仕様書原本
https://www.orca.med.or.jp/receipt/tec/api/subjectiveslst.data/api01rv2_subjectiveslstv2.pdf
