### PR TITLE
基準日の設定がある場合、基準日で保険・公費情報チェックを行えるようにした

### DIFF
--- a/example/patient_service/health_public_insurance/fetch.rb
+++ b/example/patient_service/health_public_insurance/fetch.rb
@@ -2,8 +2,10 @@
 require_relative "../../common"
 
 patient_service = @orca_api.new_patient_service
+id = ARGV.shift
+base_date = ARGV.shift
 
-result = patient_service.fetch_health_public_insurance(ARGV.shift)
+result = patient_service.fetch_health_public_insurance(id, base_date)
 if result.ok?
   pp result.patient_information
   pp result.health_public_insurance

--- a/lib/orca_api/patient_service/health_public_insurance_common.rb
+++ b/lib/orca_api/patient_service/health_public_insurance_common.rb
@@ -62,12 +62,15 @@ module OrcaApi
       #
       # @param [String] id
       #   患者ID
+      # @param [string] base_date
+      #   基準日
       # @return [Result]
       #   日レセからのレスポンス
+      #   基準日の設定がある場合は基準日で保険・公費情報のチェックを行う
       #
       # @see https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod_search
-      def fetch(id)
-        call_00(id)
+      def fetch(id, base_date = nil)
+        call_00(id, base_date)
       end
 
       # 患者保険・公費情報を更新する
@@ -189,13 +192,16 @@ module OrcaApi
 
       private
 
-      def call_00(id)
+      def call_00(id, base_date)
         req = {
           "Request_Number" => "00",
           "Patient_Information" => {
             "Patient_ID" => id.to_s,
           }
         }
+        if base_date
+          req["Base_Date"] = base_date
+        end
         call(req)
       end
 

--- a/spec/fixtures/orca_api_responses/orca12_patientmodv32_00_E00.json
+++ b/spec/fixtures/orca_api_responses/orca12_patientmodv32_00_E00.json
@@ -1,0 +1,63 @@
+{
+  "patientmodv3res2": {
+    "Request_Number": "00",
+    "Response_Number": "00",
+    "Information_Date": "2021-01-01",
+    "Information_Time": "21:00:00",
+    "Api_Result": "E00",
+    "Api_Result_Message": "検索処理終了。エラーメッセージがあります。確認して下さい。",
+    "Reskey": "Acceptance_Info",
+    "Base_Date": "2021-01-01",
+    "Patient_Information": {
+      "Patient_ID": "00003",
+      "WholeName": "テスト　太郎",
+      "WholeName_inKana": "テスト　タロウ",
+      "BirthDate": "1949-12-07",
+      "Sex": "1"
+    },
+    "HealthInsurance_Information": {
+      "HealthInsurance_Info": [
+        {
+          "InsuranceProvider_Id": "0000000001",
+          "InsuranceProvider_Class": "009",
+          "InsuranceProvider_Number": "01010016",
+          "InsuranceProvider_WholeName": "協会",
+          "HealthInsuredPerson_Symbol": "１２３４５６７８",
+          "HealthInsuredPerson_Number": "１０",
+          "RelationToInsuredPerson": "1",
+          "HealthInsuredPerson_WholeName": "前期高齢者",
+          "Certificate_StartDate": "2008-04-01",
+          "Certificate_ExpiredDate": "9999-12-31",
+          "Certificate_GetDate": "1995-02-01",
+          "Certificate_CheckDate": "2020-12-28"
+        }
+      ]
+    },
+    "HealthInsurance_Combination_Information": {
+      "HealthInsurance_Combination_Info": [
+        {
+          "Insurance_Combination_Number": "0001",
+          "Insurance_Combination_Rate_Admission": "0.30",
+          "Insurance_Combination_Rate_Outpatient": "0.30",
+          "Insurance_Combination_StartDate": "2008-04-01",
+          "Insurance_Combination_ExpiredDate": "9999-12-31",
+          "InsuranceProvider_Id": "0000000001",
+          "InsuranceProvider_Class": "009",
+          "InsuranceProvider_Number": "01010016",
+          "InsuranceProvider_WholeName": "協会",
+          "HealthInsuredPerson_Symbol": "１２３４５６７８",
+          "HealthInsuredPerson_Number": "１０",
+          "RelationToInsuredPerson": "1"
+        }
+      ]
+    },
+    "Patient_Message_Information": {
+      "Patient_Message_Info": [
+        {
+          "Patient_Result": "APP2",
+          "Patient_Result_Message": "009 協会 協会　開始日が前期高齢者の適応開始日以前です。"
+        }
+      ]
+    }
+  }
+}

--- a/spec/orca_api/patient_service/health_public_insurance_spec.rb
+++ b/spec/orca_api/patient_service/health_public_insurance_spec.rb
@@ -98,6 +98,30 @@ RSpec.describe OrcaApi::PatientService::HealthPublicInsurance, orca_api_mock: tr
 
         expect(result.ok?).to be true
       end
+
+      it  "保険・公費情報のチェックをする" do
+        expect_data = [
+          {
+            path: "/orca12/patientmodv32",
+            body: {
+              "=patientmodv3req2" => {
+                "Request_Number" => "00",
+                "Base_Date" => "2021-01-01",
+                "Patient_Information" => {
+                  "Patient_ID" => "1",
+                }
+              }
+            },
+            result: "orca12_patientmodv32_00_E00.json",
+          },
+        ]
+
+        expect_orca_api_call(expect_data, binding)
+
+        result = service.fetch(1, "2021-01-01")
+
+        expect(result.ok?).to be false
+      end
     end
 
     context "異常系" do


### PR DESCRIPTION
患者保険情報登録処理(patientmodv32)`"Request_Number=00"`にて基準日を設定できるようにした。
基準日の設定がある場合、基準日で保険・公費情報のチェックが可能になる。

ref. 
- https://www.orcamo.co.jp/api-council/members/standards/?haori_patientmod_search
- http://cms-edit.orca.med.or.jp/receipt/tec/api/haori_patientmod.data/api12v032.pdf