### PR TITLE
WebORCAを利用するためホスト名にPATHを含めることができるよう修正した

### DIFF
--- a/lib/orca_api/client.rb
+++ b/lib/orca_api/client.rb
@@ -96,6 +96,7 @@ module OrcaApi #:nodoc:
       uri = URI.parse(uri)
       @host = uri.host
       @port = uri.port
+      @base_path = uri.path
       @user = uri.user || options[:user]
       @password = uri.password || options[:password]
       @use_ssl = uri.scheme == 'https' || options[:use_ssl]
@@ -139,7 +140,7 @@ module OrcaApi #:nodoc:
     #   output_ioが指定された場合、output_ioを返す。
     #   そうでない場合、HTTPレスポンスのbodyをそのまま文字列として返す。
     def call(path, params: {}, body: nil, http_method: :post, format: "json", output_io: nil)
-      do_call make_request(http_method, path, params, body, format), output_io
+      do_call make_request(http_method, File.join(@base_path, path), params, body, format), output_io
     end
 
     # @!group 高レベルインターフェース

--- a/lib/orca_api/client.rb
+++ b/lib/orca_api/client.rb
@@ -30,6 +30,7 @@ module OrcaApi #:nodoc:
   class Client
     attr_accessor :host # ホスト名
     attr_accessor :port # ポート番号
+    attr_accessor :base_path #ベースとなるPATH
     attr_accessor :user # ユーザー名
     attr_accessor :password # パスワード
     attr_accessor :use_ssl # SSL通信をするかどうか

--- a/lib/orca_api/client.rb
+++ b/lib/orca_api/client.rb
@@ -140,7 +140,7 @@ module OrcaApi #:nodoc:
     #   output_ioが指定された場合、output_ioを返す。
     #   そうでない場合、HTTPレスポンスのbodyをそのまま文字列として返す。
     def call(path, params: {}, body: nil, http_method: :post, format: "json", output_io: nil)
-      do_call make_request(http_method, File.join(@base_path, path), params, body, format), output_io
+      do_call make_request(http_method, build_path(path), params, body, format), output_io
     end
 
     # @!group 高レベルインターフェース
@@ -394,6 +394,10 @@ module OrcaApi #:nodoc:
           raise HttpError, response
         end
       end
+    end
+
+    def build_path(path)
+      File.join(@base_path, path)
     end
   end
 

--- a/spec/orca_api/client_spec.rb
+++ b/spec/orca_api/client_spec.rb
@@ -156,6 +156,11 @@ RSpec.describe OrcaApi::Client do
           end
         end
       end
+
+      describe "base_path" do
+        let(:uri) { "http://example.com/api" }
+        its(:base_path) { is_expected.to eq("/api") }
+      end
     end
   end
 


### PR DESCRIPTION
# 概要
* WebORCAのAPIを利用するためにはFQDNの後ろに `/api` を追加する必要がある。
  * 参考: https://www.orca.med.or.jp/weborca/
    * WebORCA構築手順書を参照すること。

# 対応内容
* ホスト名の後ろに `/api` を追加することができるようになった。